### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ series = {PETRA '22}
 ## Authors
 
 * **Shailesh Mishra** was the first and main author of the MMS Player.
-* **Fabrizio Nunnari** sketched the original concept of the MMS. He is debugging, mantaining, and testing the software and coordinating further research and developments.
+* **Fabrizio Nunnari** sketched the original concept of the MMS. He is debugging, maintaining, and testing the software and coordinating further research and developments.
 
 ## Links
 


### PR DESCRIPTION
This PR fixes a small typo in the Authors section of the README:

- "mantaining" -> "maintaining"